### PR TITLE
Enable rails to be stacked

### DIFF
--- a/prototypes/public.lua
+++ b/prototypes/public.lua
@@ -157,6 +157,7 @@ local allowed_item_types = {
 	["item-with-label"] = true,
 	["item-with-tags"] = true,
 	["capsule"] = true,
+	["rail-planner"] = true
 }
 
 function deadlock.add_stack(item_name, graphic_path, target_tech, icon_size, item_type, mipmap_levels)


### PR DESCRIPTION
To enable rails to be stacked the "allowed_item_types" needs to be updated to add "rail-planner"

Fixes #15 