### PR TITLE
Allow T3/T4 recipes to be made in foundary, fix T4 ingredients

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@ Version: 2.6.0
 Date: 06. 01. 2025
   Changes:
     - Corrected the recipe for T4 loaders/beltboxes to use T3 instead of T2
-    - Allow T3 loaders/beltboxes to be made in foundaries when Space Age is present, matching the belts of that tier
+    - Allow T3/T4 loaders/beltboxes to be made in foundaries when Space Age is present, matching the belts of that tier
 ---------------------------------------------------------------------------------------------------
 Version: 2.5.0
 Date: 23. 10. 2024

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,13 +1,17 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.6.0
+Date: 06. 01. 2025
+  Changes:
+    - Corrected the recipe for T4 loaders/beltboxes to use T3 instead of T2
+    - Allow T3 loaders/beltboxes to be made in foundaries when Space Age is present, matching the belts of that tier
+---------------------------------------------------------------------------------------------------
 Version: 2.5.0
 Date: 23. 10. 2024
   Changes:
-    - Updated for Factorio 2.0.
-    - Added compatibility with Space Age, a 4th tier of loaders/beltboxes will be added if Space Age is active.
-    - Turbo loaders/beltboxes are NOT localized in other langs, only Eng.
-    - Removed the 'low' graphics as `hr_version` as the low/high split has been removed from the game.
-    - Not everything tested, but made sure loaders/beltboxes work.
-    - Migrations untested. I wouldn't recommend using an old save in 2.0 in the first place.
+    - Updated for Factorio 2.0
+    - Added compatibility with Space Age, a 4th tier of loaders/beltboxes will be added if Space Age is active
+    - Turbo loaders/beltboxes are currently only localized in English, PRs with translations are welcome!
+    - Removed the 'low' graphics as `hr_version` as the low/high split has been removed from the game
 ---------------------------------------------------------------------------------------------------
 Version: 2.4.2
 Date: 09. 05. 2021

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "deadlock-beltboxes-loaders",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "title": "Deadlock's Stacking Beltboxes & Compact Loaders",
     "author": "Deadlock989, Shane Madden, MasterBuilder",
     "homepage": "https://forums.factorio.com/viewtopic.php?f=94&t=57264",

--- a/prototypes/vanilla_tiers.lua
+++ b/prototypes/vanilla_tiers.lua
@@ -68,18 +68,24 @@ deadlock.add_tier({
 		{name = "iron-gear-wheel", type = "item", amount = 40},
 		{name = "lubricant", type = "fluid", amount = 20},
 	},
-	loader_category     = "crafting-with-fluid",
+	loader_category     = "crafting-with-fluid-or-metallurgy",
 	beltbox_ingredients = {
 		{name = "fast-transport-belt-beltbox", type = "item", amount = 1},
 		{name = "iron-plate", type = "item", amount = 30},
 		{name = "iron-gear-wheel", type = "item", amount = 30},
 		{name = "lubricant", type = "fluid", amount = 100},
 	},
-	beltbox_category    = "crafting-with-fluid",
+	beltbox_category    = "crafting-with-fluid-or-metallurgy",
 	beltbox_technology  = "deadlock-stacking-3",
 })
 if data.raw.technology["deadlock-stacking-3"] then
 	table.insert(data.raw.technology["deadlock-stacking-3"].prerequisites, "deadlock-stacking-2")
+end
+if data.raw["loader-1x1"]["express-transport-belt-loader"] then
+	data.raw["loader-1x1"]["express-transport-belt-loader"].next_upgrade = "turbo-transport-belt-loader"
+end
+if data.raw.furnace["express-transport-belt-beltbox"] then
+	data.raw.furnace["express-transport-belt-beltbox"].next_upgrade = "turbo-transport-belt-beltbox"
 end
 
 if mods["space-age"] then
@@ -92,18 +98,18 @@ if mods["space-age"] then
         technology          = "turbo-transport-belt",
         order               = "d",
         loader_ingredients  = {
-            {name = "fast-transport-belt-loader", type = "item", amount = 1},
+            {name = "express-transport-belt-loader", type = "item", amount = 1},
             {name = "tungsten-plate", type = "item", amount = 20},
             {name = "lubricant", type = "fluid", amount = 20},
         },
-        loader_category     = "crafting-with-fluid",
+        loader_category     = "crafting-with-fluid-or-metallurgy",
         beltbox_ingredients = {
-            {name = "fast-transport-belt-beltbox", type = "item", amount = 1},
+            {name = "express-transport-belt-beltbox", type = "item", amount = 1},
             {name = "tungsten-plate", type = "item", amount = 15},
             {name = "iron-gear-wheel", type = "item", amount = 15},
             {name = "lubricant", type = "fluid", amount = 100},
         },
-        beltbox_category    = "crafting-with-fluid",
+        beltbox_category    = "crafting-with-fluid-or-metallurgy",
         beltbox_technology  = "deadlock-stacking-4",
     })
     if data.raw.technology["deadlock-stacking-4"] then

--- a/prototypes/vanilla_tiers.lua
+++ b/prototypes/vanilla_tiers.lua
@@ -55,6 +55,14 @@ if data.raw.furnace["fast-transport-belt-beltbox"] then
 	data.raw.furnace["fast-transport-belt-beltbox"].next_upgrade = "express-transport-belt-beltbox"
 end
 
+-- vary which category t3 is used for depending on whether space age is present
+local t3_category
+if mods["space-age"] then
+	t3_category = "crafting-with-fluid-or-metallurgy"
+else
+	t3_category = "crafting-with-fluid"
+end
+
 -- tier 3
 deadlock.add_tier({
 	transport_belt      = "express-transport-belt",
@@ -68,51 +76,53 @@ deadlock.add_tier({
 		{name = "iron-gear-wheel", type = "item", amount = 40},
 		{name = "lubricant", type = "fluid", amount = 20},
 	},
-	loader_category     = "crafting-with-fluid-or-metallurgy",
+	loader_category     = t3_category,
 	beltbox_ingredients = {
 		{name = "fast-transport-belt-beltbox", type = "item", amount = 1},
 		{name = "iron-plate", type = "item", amount = 30},
 		{name = "iron-gear-wheel", type = "item", amount = 30},
 		{name = "lubricant", type = "fluid", amount = 100},
 	},
-	beltbox_category    = "crafting-with-fluid-or-metallurgy",
+	beltbox_category    = t3_category,
 	beltbox_technology  = "deadlock-stacking-3",
 })
 if data.raw.technology["deadlock-stacking-3"] then
 	table.insert(data.raw.technology["deadlock-stacking-3"].prerequisites, "deadlock-stacking-2")
 end
-if data.raw["loader-1x1"]["express-transport-belt-loader"] then
-	data.raw["loader-1x1"]["express-transport-belt-loader"].next_upgrade = "turbo-transport-belt-loader"
-end
-if data.raw.furnace["express-transport-belt-beltbox"] then
-	data.raw.furnace["express-transport-belt-beltbox"].next_upgrade = "turbo-transport-belt-beltbox"
-end
 
 if mods["space-age"] then
-    -- tier 4
-    deadlock.add_tier({
-        transport_belt      = "turbo-transport-belt",
-        colour              = {r=160, g=190, b=80},
-        underground_belt    = "turbo-underground-belt",
-        splitter            = "turbo-splitter",
-        technology          = "turbo-transport-belt",
-        order               = "d",
-        loader_ingredients  = {
-            {name = "express-transport-belt-loader", type = "item", amount = 1},
-            {name = "tungsten-plate", type = "item", amount = 20},
-            {name = "lubricant", type = "fluid", amount = 20},
-        },
-        loader_category     = "crafting-with-fluid-or-metallurgy",
-        beltbox_ingredients = {
-            {name = "express-transport-belt-beltbox", type = "item", amount = 1},
-            {name = "tungsten-plate", type = "item", amount = 15},
-            {name = "iron-gear-wheel", type = "item", amount = 15},
-            {name = "lubricant", type = "fluid", amount = 100},
-        },
-        beltbox_category    = "crafting-with-fluid-or-metallurgy",
-        beltbox_technology  = "deadlock-stacking-4",
-    })
-    if data.raw.technology["deadlock-stacking-4"] then
-        table.insert(data.raw.technology["deadlock-stacking-4"].prerequisites, "deadlock-stacking-3")
-    end
+	-- add the upgrade for t3 only if space age is present and we're gonna be loading t4
+	if data.raw["loader-1x1"]["express-transport-belt-loader"] then
+		data.raw["loader-1x1"]["express-transport-belt-loader"].next_upgrade = "turbo-transport-belt-loader"
+	end
+	if data.raw.furnace["express-transport-belt-beltbox"] then
+		data.raw.furnace["express-transport-belt-beltbox"].next_upgrade = "turbo-transport-belt-beltbox"
+	end
+
+	-- tier 4
+	deadlock.add_tier({
+		transport_belt      = "turbo-transport-belt",
+		colour              = {r=160, g=190, b=80},
+		underground_belt    = "turbo-underground-belt",
+		splitter            = "turbo-splitter",
+		technology          = "turbo-transport-belt",
+		order               = "d",
+		loader_ingredients  = {
+			{name = "express-transport-belt-loader", type = "item", amount = 1},
+			{name = "tungsten-plate", type = "item", amount = 20},
+			{name = "lubricant", type = "fluid", amount = 20},
+		},
+		loader_category     = "crafting-with-fluid-or-metallurgy",
+		beltbox_ingredients = {
+			{name = "express-transport-belt-beltbox", type = "item", amount = 1},
+			{name = "tungsten-plate", type = "item", amount = 15},
+			{name = "iron-gear-wheel", type = "item", amount = 15},
+			{name = "lubricant", type = "fluid", amount = 100},
+		},
+		beltbox_category    = "crafting-with-fluid-or-metallurgy",
+		beltbox_technology  = "deadlock-stacking-4",
+	})
+	if data.raw.technology["deadlock-stacking-4"] then
+		table.insert(data.raw.technology["deadlock-stacking-4"].prerequisites, "deadlock-stacking-3")
+	end
 end


### PR DESCRIPTION
Fix T4 loader recipe for Foundry production and proper tier progression (use T3 loader rather than T2 loader as ingredient); T3 loader can be made in foundry